### PR TITLE
Fix: Use official Figma plugin typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
     "url": "https://github.com/okotoki/figma-messenger/issues"
   },
   "homepage": "https://github.com/okotoki/figma-messenger#readme",
+  "peerDependencies": {
+    "@figma/plugin-typings": ">=1.0.0"
+  },
   "devDependencies": {
-    "@types/figma": "^1.0.3",
+    "@figma/plugin-typings": "^1.0.0",
     "tslint": "^6.1.2",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.3.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,6 @@ export enum MessengerType {
   main = 'main'
 }
 
-declare global {
-  const figma: any
-}
-
 export type Listener = (...args: any[]) => void
 
 export interface ListenersStore {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "typeRoots": ["node_modules/@types", "./custom_typings"],
+    "types": ["@figma/plugin-typings"],
     "moduleResolution": "node",
     "skipLibCheck": true,
     "baseUrl": "./src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@types/figma@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@types/figma/-/figma-1.0.3.tgz#961a613c4de0627d520a16b7f82fe9627481e27f"
-  integrity sha512-2jDGdTYyLabbRxAKLceNS7mfo06bwknvI27CGLbl7UKobHmIZ+HW/1dWEsLE0SC4yPf3/sL1l5atw3YCUXhJHQ==
+"@figma/plugin-typings@^1.0.0":
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.82.0.tgz#7f8c8514bb18dc303e3b194b60827fec1f2a5e9f"
+  integrity sha512-To5M9VRpNysrGGtZtPF5Ke9eobfhTUr7kieAsYMhpPg+VKdr0EM6XDFtCqhtuDrLfPAZFa/cBQo68auWwD4mlA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Closes #26 

Removes the generic `figma: any` global typing and replaces with `@figma/plugin-typings` instead.